### PR TITLE
Feature/ignore_undefined_field_names setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ The configuration is also captured in [tables_config_util.py](tap_spreadsheets_a
                 "first_name": {
                     "type": "string",
                 }
-            }
+            },
+            "ignore_undefined_field_names": true
         },
         {
             "path": "sftp://username:password@host//path/file",
@@ -116,7 +117,8 @@ Each object in the 'tables' array describes one or more CSV or Excel spreadsheet
 - **worksheet_name**: (optional) the worksheet name to pull from in the targeted xls file(s). Only required when format is excel
 - **delimiter**: (optional) the delimiter to use when format is 'csv'. Defaults to a comma ',' but you can set delimiter to 'detect' to leverage the csv "Sniffer" for auto-detecting delimiter. 
 - **quotechar**: (optional) the character used to surround values that may contain delimiters - defaults to a double quote '"'
-- **json_path**: (optional) the JSON key under which the list of objets to use is located. Defaults to None, corresponding to an array at the top level of the JSON tree.
+- **json_path**: (optional) the JSON key under which the list of objects to use is located. Defaults to None, corresponding to an array at the top level of the JSON tree.
+**ignore_undefined_field_names**: (optional) when enabled this removes all catalog entries where the field name is undefined (empty string), as these fields always cause errors with database targets. `Boolean` that defaults to `false`.
 
 ### Automatic Config Generation
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-spreadsheets-anywhere",
-    version="0.2.1",
+    version="0.3.0",
     description="Singer.io tap for extracting spreadsheet data from cloud storage",
     author="Eric Simmerman",
     url="https://github.com/ets/tap-spreadsheets-anywhere",

--- a/tap_spreadsheets_anywhere/__init__.py
+++ b/tap_spreadsheets_anywhere/__init__.py
@@ -66,8 +66,10 @@ def discover(config):
             sample_rate = table_spec.get('sample_rate',5)
             max_sampling_read = table_spec.get('max_sampling_read', 1000)
             max_sampled_files = table_spec.get('max_sampled_files', 50)
-            samples = file_utils.sample_files(table_spec, target_files,sample_rate=sample_rate,
-                                              max_records=max_sampling_read, max_files=max_sampled_files)
+            samples = file_utils.sample_files(table_spec, target_files,
+                                              table_spec.get("ignore_undefined_field_names", False),
+                                              sample_rate=sample_rate, max_records=max_sampling_read,
+                                              max_files=max_sampled_files)
             schema = generate_schema(table_spec, samples)
             stream_metadata = []
             key_properties = table_spec.get('key_properties', [])

--- a/tap_spreadsheets_anywhere/configuration.py
+++ b/tap_spreadsheets_anywhere/configuration.py
@@ -35,7 +35,8 @@ CONFIG_CONTRACT = Schema({
                 Required('type'): Any(Any('null','string','integer','number','date-time','object'),
                                       [Any('null','string','integer','number','date-time','object')])
             }
-        }
+        },
+        Optional('ignore_undefined_field_names'): bool,
     }]
 })
 

--- a/tap_spreadsheets_anywhere/file_utils.py
+++ b/tap_spreadsheets_anywhere/file_utils.py
@@ -74,7 +74,7 @@ def write_file(target_filename, table_spec, schema, max_records=-1):
     return records_synced
 
 
-def sample_file(table_spec, target_filename, sample_rate, max_records):
+def sample_file(table_spec, target_filename, ignore_undefined_field_names, sample_rate, max_records):
     LOGGER.info('Sampling {} ({} records, every {}th record).'
                 .format(target_filename, max_records, sample_rate))
 
@@ -97,18 +97,23 @@ def sample_file(table_spec, target_filename, sample_rate, max_records):
         else:
             LOGGER.exception(f"Unable to parse {target_filename}",ife)
 
+    if ignore_undefined_field_names:
+        for row in samples:
+            row.pop('', None)
+
     LOGGER.info('Sampled {} records.'.format(len(samples)))
     return samples
 
 
-def sample_files(table_spec, target_files,
+def sample_files(table_spec, target_files, ignore_undefined_field_names,
                  sample_rate=10, max_records=1000, max_files=5):
     to_return = []
 
     files_so_far = 0
 
     for target_file in target_files:
-        to_return += sample_file(table_spec, target_file['key'], sample_rate, max_records)
+        to_return += sample_file(table_spec, target_file['key'], ignore_undefined_field_names,
+                                sample_rate, max_records)
         files_so_far += 1
 
         if files_so_far >= max_files:

--- a/tap_spreadsheets_anywhere/test/test_format.py
+++ b/tap_spreadsheets_anywhere/test/test_format.py
@@ -152,7 +152,8 @@ class TestFormatHandler(unittest.TestCase):
             table_spec = TEST_TABLE_SPEC['tables'][7]
             modified_since = dateutil.parser.parse(table_spec['start_date'])
             target_files = file_utils.get_matching_objects(table_spec, modified_since)
-            samples = file_utils.sample_files(table_spec, target_files, sample_rate=1)
+            ignore_undefined_field_names = False
+            samples = file_utils.sample_files(table_spec, target_files, ignore_undefined_field_names, sample_rate=1)
             schema = generate_schema(table_spec, samples)
             for t_file in target_files:
                 records_streamed += file_utils.write_file(t_file['key'], table_spec, schema.to_dict())
@@ -208,6 +209,34 @@ class TestFormatHandler(unittest.TestCase):
 
         row = next(iterator)
         self.assertTrue(len(row)>1,"Not able to read a row.")
+
+
+
+
+class TestFormatHandlerExcelXlsxIgnoreUndefinedFieldNames(unittest.TestCase):
+
+    def test_ignore_undefined_field_names_true(self):
+        table_spec = TEST_TABLE_SPEC['tables'][2]
+        modified_since = dateutil.parser.parse(table_spec['start_date'])
+        target_files = file_utils.get_matching_objects(table_spec, modified_since)
+        ignore_undefined_field_names = True
+
+        samples = file_utils.sample_files(table_spec, target_files, ignore_undefined_field_names, sample_rate=1)
+
+        # Should find only the 3 named columns in the sheet
+        self.assertTrue(len(samples[1]) == 3, "Found more than expected 3 columns")
+
+    def test_ignore_undefined_field_names_false(self):
+        table_spec = TEST_TABLE_SPEC['tables'][2]
+        modified_since = dateutil.parser.parse(table_spec['start_date'])
+        target_files = file_utils.get_matching_objects(table_spec, modified_since)
+        ignore_undefined_field_names = False
+
+        samples = file_utils.sample_files(table_spec, target_files, ignore_undefined_field_names, sample_rate=1)
+
+        # This assert is 4 as sample_files finds 3 names columns, 3 unnamed, but merges all
+        # of the unnamed columns into one "entry" in the catalog as an empty string
+        self.assertTrue(len(samples[1]) == 4, "Found more than expected 4 columns")
 
 
 class TestFormatHandlerExcelXlsxSkipInitial:


### PR DESCRIPTION
closes #1 

- Add a new setting called `ignore_undefined_field_names`, that removed fields with undefined names from streams/catalogs of tables. This setting is designed to be used for database targets as they expect a not null or empty string as the column name.

It's an `optional` setting, of type `Boolean` and the default value is `false`

- Added tests around this new setting, one for the `false` default value behavior and one for when the setting is enabled.
- Updated README with example of for the new setting, and added it to the table of settings
- Bumped tap version to `0.3.0`