### PR TITLE
Fix/fix syncing remote xlsx files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-spreadsheets-anywhere",
-    version="0.3.2",
+    version="0.3.3",
     description="Singer.io tap for extracting spreadsheet data from cloud storage",
     author="Eric Simmerman",
     url="https://github.com/ets/tap-spreadsheets-anywhere",

--- a/tap_spreadsheets_anywhere/excel_handler.py
+++ b/tap_spreadsheets_anywhere/excel_handler.py
@@ -4,6 +4,8 @@ import logging
 
 import xlrd
 
+from io import BytesIO
+
 LOGGER = logging.getLogger(__name__)
 
 def generator_wrapper(reader, table_spec: dict={}) -> dict:
@@ -69,7 +71,7 @@ def get_legacy_row_iterator(table_spec, file_handle):
 
 
 def get_row_iterator(table_spec, file_handle):
-    workbook = openpyxl.load_workbook(file_handle.name, read_only=True)
+    workbook = openpyxl.load_workbook(BytesIO(file_handle.read()), read_only=True)
     
     if "worksheet_name" in table_spec:
         try:


### PR DESCRIPTION
- Updated the logic for opening `.xlsx` file to use bytes of the file rather than just being passed a path without a protocol, which was then treated as a local path and always causing a `FileNotFound` error when connecting to remote files.
- Bumped version to `0.3.3`