### PR TITLE
Feature/ignore state setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ The configuration is also captured in [tables_config_util.py](tap_spreadsheets_a
                     "type": "string",
                 }
             },
-            "ignore_undefined_field_names": true
+            "ignore_undefined_field_names": true,
+            "ignore_state": true
         },
         {
             "path": "sftp://username:password@host//path/file",
@@ -122,6 +123,7 @@ Each object in the 'tables' array describes one or more CSV or Excel spreadsheet
 - **quotechar**: (optional) the character used to surround values that may contain delimiters - defaults to a double quote '"'
 - **json_path**: (optional) the JSON key under which the list of objects to use is located. Defaults to None, corresponding to an array at the top level of the JSON tree.
 - **ignore_undefined_field_names**: (optional) when enabled this removes all catalog entries where the field name is undefined (empty string), as these fields always cause errors with database targets. `Boolean` that defaults to `false`.
+- **ignore_state**: (optional) when enabled this ignores the state for the specific table, this means we will default to getting all the applicable files from the **start_date** you have provided.
 
 ### Other Optional Tap Settings
 

--- a/tap_spreadsheets_anywhere/__init__.py
+++ b/tap_spreadsheets_anywhere/__init__.py
@@ -113,6 +113,11 @@ def sync(config, state, catalog):
             )
             modified_since = dateutil.parser.parse(
                 state.get(stream.tap_stream_id, {}).get('modified_since') or table_spec['start_date'])
+
+            modified_since = dateutil.parser.parse(table_spec['start_date']) if table_spec.get('ignore_state', False) else modified_since
+
+            LOGGER.debug(modified_since)
+
             target_files = file_utils.get_matching_objects(table_spec, modified_since)
             max_records_per_run = table_spec.get('max_records_per_run', -1)
             records_streamed = 0

--- a/tap_spreadsheets_anywhere/__init__.py
+++ b/tap_spreadsheets_anywhere/__init__.py
@@ -116,8 +116,6 @@ def sync(config, state, catalog):
 
             modified_since = dateutil.parser.parse(table_spec['start_date']) if table_spec.get('ignore_state', False) else modified_since
 
-            LOGGER.debug(modified_since)
-
             target_files = file_utils.get_matching_objects(table_spec, modified_since)
             max_records_per_run = table_spec.get('max_records_per_run', -1)
             records_streamed = 0

--- a/tap_spreadsheets_anywhere/configuration.py
+++ b/tap_spreadsheets_anywhere/configuration.py
@@ -37,6 +37,7 @@ CONFIG_CONTRACT = Schema({
             }
         },
         Optional('ignore_undefined_field_names'): bool,
+        Optional('ignore_state'): bool,
     }],
     Optional('azure_storage_connection_string'): str,
     Optional('aws_access_key_id'): str,

--- a/tap_spreadsheets_anywhere/test/test_config.py
+++ b/tap_spreadsheets_anywhere/test/test_config.py
@@ -15,6 +15,48 @@ TEST_CRAWL_SPEC = {
     ]
 }
 
+TEST_TABLE_SPEC = {
+    "tables": [
+        {
+            "path": "file://./artifacts",
+            "name": "badnewlines",
+            "pattern": '.*\\.csv',
+            "start_date": "2017-05-01T00:00:00Z",
+            "key_properties": [],
+            "format": "csv",
+            "universal_newlines": False,
+            "sample_rate": 5,
+            "max_sampling_read": 2000,
+            "max_sampled_files": 3
+        },
+        {
+            "path": "file://./artifacts",
+            "name": "badnewlines",
+            "pattern": '.*\\.csv',
+            "start_date": "2024-01-01T00:00:00Z",
+            "key_properties": [],
+            "format": "csv",
+            "universal_newlines": False,
+            "sample_rate": 5,
+            "max_sampling_read": 2000,
+            "max_sampled_files": 3
+        },
+        {
+            "path": "file://./artifacts",
+            "name": "badnewlines",
+            "pattern": '.*\\.csv',
+            "start_date": "2017-05-01T00:00:00Z",
+            "key_properties": [],
+            "format": "csv",
+            "universal_newlines": False,
+            "sample_rate": 5,
+            "max_sampling_read": 2000,
+            "max_sampled_files": 3,
+            "ignore_state": True
+        }
+    ]
+}
+
 
 class TestFormatHandler(unittest.TestCase):
 
@@ -25,4 +67,31 @@ class TestFormatHandler(unittest.TestCase):
                         "config did not crawl and parse as expected!")
 
 
+class TestConfigStartDate(unittest.TestCase):
 
+    def test_config_with_start_date_less_than_file_modified_date(self):
+        table_spec = TEST_TABLE_SPEC['tables'][0]
+        modified_since = dateutil.parser.parse(table_spec['start_date'])
+        target_files = file_utils.get_matching_objects(table_spec, modified_since)
+        assert len(target_files) == 1
+
+    def test_config_with_start_date_greater_than_file_modified_date(self):
+        table_spec = TEST_TABLE_SPEC['tables'][1]
+        modified_since = dateutil.parser.parse(table_spec['start_date'])
+        target_files = file_utils.get_matching_objects(table_spec, modified_since)
+        assert len(target_files) == 0
+
+
+class TestConfigIgnoreState(unittest.TestCase):
+
+    def test_config_ignore_state_true(self):
+        table_spec = TEST_TABLE_SPEC['tables'][2]
+
+        # This is the logic if state was found in the sync function.
+        # 2024-01-01T00:00:00Z as our dummy state so this should not find any files unless we ignore_state
+        modified_since = "2024-01-01T00:00:00Z"
+        modified_since = table_spec['start_date'] if table_spec.get('ignore_state') else modified_since
+
+        modified_since = dateutil.parser.parse(table_spec['start_date'])
+        target_files = file_utils.get_matching_objects(table_spec, modified_since)
+        assert len(target_files) == 1


### PR DESCRIPTION
Adds a new setting `ignore_state` at the table level, that lets users 'full_table' sync their data from their explicit `start_date` setting. It has to be handled this way as the tap itself is reading and setting state with no `replication_method` availability.

- Added unit tests for new `ignore_state` setting as well as `start_date` as these are intertwined
- Added docs for `ignore_state` in the README