### PR TITLE
Discover from state, IMAP limit, missing`file` protocol handling regression

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ The configuration is also captured in [tables_config_util.py](tap_spreadsheets_a
                 }
             },
             "ignore_undefined_field_names": true,
-            "ignore_state": true
+            "ignore_state": true,
+            "state_based_discovery": true
         },
         {
             "path": "sftp://username:password@host//path/file",
@@ -127,6 +128,7 @@ Each object in the 'tables' array describes one or more CSV or Excel spreadsheet
 - **json_path**: (optional) the JSON key under which the list of objects to use is located. Defaults to None, corresponding to an array at the top level of the JSON tree.
 - **ignore_undefined_field_names**: (optional) when enabled this removes all catalog entries where the field name is undefined (empty string), as these fields always cause errors with database targets. `Boolean` that defaults to `false`.
 - **ignore_state**: (optional) when enabled this ignores the state for the specific table, this means we will default to getting all the applicable files from the **start_date** you have provided.
+- **state_based_discovery**: (optional) when enabled makes discovery only happen to files found after the streams state. (Currently this only effects the IMAP protocol, paths starting `imap://`).
 
 ### Other Optional Tap Settings
 

--- a/tap_spreadsheets_anywhere/__init__.py
+++ b/tap_spreadsheets_anywhere/__init__.py
@@ -72,9 +72,6 @@ def discover(config):
             max_sampled_files = table_spec.get('max_sampled_files', 50)
             modified_since = dateutil.parser.parse(state_modified_since or table_spec['start_date'])
             target_files = file_utils.get_matching_objects(table_spec, modified_since, max_sampled_files)
-            sample_rate = table_spec.get('sample_rate',5)
-            max_sampling_read = table_spec.get('max_sampling_read', 1000)
-            max_sampled_files = table_spec.get('max_sampled_files', 50)
             samples = file_utils.sample_files(table_spec, target_files,
                                               table_spec.get("ignore_undefined_field_names", False),
                                               sample_rate=sample_rate, max_records=max_sampling_read,

--- a/tap_spreadsheets_anywhere/__init__.py
+++ b/tap_spreadsheets_anywhere/__init__.py
@@ -62,10 +62,15 @@ def discover(config):
     streams = []
     for table_spec in config['tables']:
         try:
+            state_modified_since = (
+                utils.parse_args(['tables']).state.get(table_spec['name'], {}).get("modified_since")
+                if table_spec.get('state_based_discovery')
+                else None
+            )
             sample_rate = table_spec.get('sample_rate',5)
             max_sampling_read = table_spec.get('max_sampling_read', 1000)
             max_sampled_files = table_spec.get('max_sampled_files', 50)
-            modified_since = dateutil.parser.parse(table_spec['start_date'])
+            modified_since = dateutil.parser.parse(state_modified_since or table_spec['start_date'])
             target_files = file_utils.get_matching_objects(table_spec, modified_since, max_sampled_files)
             sample_rate = table_spec.get('sample_rate',5)
             max_sampling_read = table_spec.get('max_sampling_read', 1000)

--- a/tap_spreadsheets_anywhere/__init__.py
+++ b/tap_spreadsheets_anywhere/__init__.py
@@ -62,8 +62,11 @@ def discover(config):
     streams = []
     for table_spec in config['tables']:
         try:
+            sample_rate = table_spec.get('sample_rate',5)
+            max_sampling_read = table_spec.get('max_sampling_read', 1000)
+            max_sampled_files = table_spec.get('max_sampled_files', 50)
             modified_since = dateutil.parser.parse(table_spec['start_date'])
-            target_files = file_utils.get_matching_objects(table_spec, modified_since)
+            target_files = file_utils.get_matching_objects(table_spec, modified_since, max_sampled_files)
             sample_rate = table_spec.get('sample_rate',5)
             max_sampling_read = table_spec.get('max_sampling_read', 1000)
             max_sampled_files = table_spec.get('max_sampled_files', 50)

--- a/tap_spreadsheets_anywhere/configuration.py
+++ b/tap_spreadsheets_anywhere/configuration.py
@@ -40,6 +40,7 @@ CONFIG_CONTRACT = Schema({
         Optional('ignore_undefined_field_names'): bool,
         Optional('ignore_state'): bool,
         Optional('skip_empty_rows'): bool,
+        Optional('state_based_discovery'): bool,
     }],
     Optional('azure_storage_connection_string'): str,
     Optional('aws_access_key_id'): str,

--- a/tap_spreadsheets_anywhere/file_utils.py
+++ b/tap_spreadsheets_anywhere/file_utils.py
@@ -168,9 +168,9 @@ def get_matching_objects(table_spec, modified_since=None, max_sampled_files=None
     elif protocol in ["imap"]:
         target_objects = list_files_in_imap_mailbox(
             table_spec["path"],
-            max_sampled_files,
             table_spec.get("search_prefix"),
-            modified_since
+            modified_since,
+            max_sampled_files,
         )
     else:
         raise ValueError("Protocol {} not yet supported. Pull Requests are welcome!")
@@ -355,9 +355,9 @@ def list_files_in_s3_bucket(bucket, search_prefix=None):
 @lru_cache
 def list_files_in_imap_mailbox(
     uri: str,
-    max_sampled_files: int,
     search_prefix: str | None = None,
     modified_since: datetime | None = None,
+    max_sampled_files: int | None = None,
 ):
     parsed = urlparse(uri)
     fs = tap_spreadsheets_anywhere.format_handler.get_imap_fs(parsed.netloc)

--- a/tap_spreadsheets_anywhere/format_handler.py
+++ b/tap_spreadsheets_anywhere/format_handler.py
@@ -60,6 +60,9 @@ def get_transport_params(protocol: str):
             **config.get("oauth_credentials", {}),
         }
 
+    if protocol == "file":
+        return {}
+
     msg = f"Protocol '{protocol}' not supported"
     raise ValueError(msg)
 


### PR DESCRIPTION
- Implement discovery from state timestamp via `state_based_discovery` config flag, to ensure new files are sampled
- Pass limit to IMAP backend from `max_sampled_files` config value to improve performance
- Fix regression with missing `file` protocol for local paths