### PR TITLE
fix(MEL-350): Resolve "Skipping processing" warning for every non-matching table spec

### DIFF
--- a/tap_spreadsheets_anywhere/__init__.py
+++ b/tap_spreadsheets_anywhere/__init__.py
@@ -109,11 +109,13 @@ def sync(config, state, catalog):
         LOGGER.info("Syncing stream:" + stream.tap_stream_id)
         catalog_schema = stream.schema.to_dict()
         state_modified_since = state.get(stream.tap_stream_id, {}).get("modified_since")
-        for table_spec in config['tables']:
-            if table_spec['name'] != stream.tap_stream_id:
-                LOGGER.warn(f'Skipping processing for stream [{stream.tap_stream_id}] without a config block.')
-                continue
+        table_specs = [t for t in config['tables'] if t['name'] == stream.tap_stream_id]
 
+        if not table_specs:
+            LOGGER.warn(f'Skipping processing for stream [{stream.tap_stream_id}] without a config block.')
+            continue
+
+        for table_spec in table_specs:
             # Allow updates to our tables specification to override any previously extracted schema in the catalog
             merged_schema = override_schema_with_config(catalog_schema, table_spec)
             singer.write_schema(

--- a/tap_spreadsheets_anywhere/__init__.py
+++ b/tap_spreadsheets_anywhere/__init__.py
@@ -112,7 +112,7 @@ def sync(config, state, catalog):
         table_specs = [t for t in config['tables'] if t['name'] == stream.tap_stream_id]
 
         if not table_specs:
-            LOGGER.warn(f'Skipping processing for stream [{stream.tap_stream_id}] without a config block.')
+            LOGGER.warning(f'Skipping processing for stream [{stream.tap_stream_id}] without a config block.')
             continue
 
         for table_spec in table_specs:


### PR DESCRIPTION
Previously, a "Skipping processing" warning log was emitted for every non-matching table spec. This problem compounded with larger `tables` config (i.e. many table specs):
- 1 table spec: 0 total warnings (0 per stream)
- 2 table specs: 2 total warnings (1 per stream)
- 4 table specs: 12 total warnings (3 per stream)
- 8 table specs: 57 total warnings (7 per stream)
- 16 table specs: 240 total warnings (15 per stream)
- 32 table specs: 992 total warnings (31 per stream)
- 64 table specs: 4032 total warnings (63 per stream)
- _n_ table specs: _n<sup>2</sup>&minus;n_ total warnings (_n&minus;1_ per stream)

This fix ensures we resolve the matching table specs beforehand and iterate over those. A warning is emitted only if no matching tables specs are found.